### PR TITLE
feat: add predicted levels heading for DAQI tabs

### DIFF
--- a/src/server/check-local-air-quality/controller.js
+++ b/src/server/check-local-air-quality/controller.js
@@ -16,6 +16,7 @@ const handleHomeRequest = (request, h, content = english) => {
     description: home.description,
     metaSiteUrl,
     heading: home.heading,
+    predictedLevelsHeading: content.predictedLevelsHeading,
     page: home.page,
     paragraphs: home.paragraphs,
     label: home.button,

--- a/src/server/check-local-air-quality/cy/controller.js
+++ b/src/server/check-local-air-quality/cy/controller.js
@@ -25,6 +25,7 @@ const handleHomeRequest = (request, h, content = welsh) => {
     description: home.description,
     metaSiteUrl,
     heading: home.heading,
+    predictedLevelsHeading: content.predictedLevelsHeading,
     page: home.page,
     paragraphs: home.paragraphs,
     label: home.button,

--- a/src/server/common/templates/partials/daqi-numbered.njk
+++ b/src/server/common/templates/partials/daqi-numbered.njk
@@ -2,6 +2,12 @@
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {# Use existing date filters from legacy forecast templates '' #}
 {% if airQuality and airQuality.today %}
+
+{# Display the predicted levels heading above the tabs if provided #}
+{% if predictedLevelsHeading %}
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ predictedLevelsHeading }}</h2>
+{% endif %}
+
 {# '' First tab label is translatable via content files #}
 {% set todayAbbrev = daqi.tabs.today | default('Today') %}
 
@@ -28,18 +34,14 @@
 
 {% set todayPanel %}
   <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ todayAbbrev }}</h2>
-  {% if lang == "en" %}
-    <span class="govuk-caption-s govuk-!-margin-bottom-4">Daily Air Quality Index (DAQI)</span>
-  {% else %}
-    <span class="govuk-caption-s govuk-!-margin-bottom-4">Mynegai Ansawdd Aer Dyddiol (DAQI)</span>
-  {% endif %}
+  <span class="govuk-caption-s govuk-!-margin-bottom-4">{{ daqi.heading }}</span>
   {{ daqiNumberedBar(airQuality.today.value | default(0), airQuality.today.readableBand | default('')) }}
 
   {# Add daily summary details for today #}
-  {% if transformedDailySummary and transformedDailySummary.Today %}
+  {% if transformedDailySummary and (transformedDailySummary.Today or transformedDailySummary.Heddiw) %}
     <div class="daqitab-summary govuk-!-margin-top-6">
       <h3 class="govuk-heading-s">{{ daqi.pageTexts.e }}</h3>
-      <p>{{ transformedDailySummary.Today }}</p>
+      <p>{{ transformedDailySummary.Today or transformedDailySummary.Heddiw }}</p>
       
       <p>{{ daqi.predictionLinkText }} <a href="#" class="govuk-link">{{ daqi.predictionLink }}</a></p>
       
@@ -66,15 +68,15 @@
 
 {# Dynamic forecast days using existing date filters and coloring '' #}
 {% if airQuality.day2 %}
-  {% set day2Label = 1 | addDaysToTodayAbrev %}
+  {% if lang == "en" %}
+    {% set day2Label = 1 | addDaysToTodayAbrev %}
+  {% else %}
+    {% set day2Label = 1 | addDaysToTodayAbrevWelsh %}
+  {% endif %}
   {% set day2TabClass = "govuk-tabs__tab daqi-tab--" + (airQuality.day2.value | default(0) | string) %}
   {% set day2Panel %}
     <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ day2Label }}</h2>
-    {% if lang == "en" %}
-      <span class="govuk-caption-s govuk-!-margin-bottom-4">Daily Air Quality Index (DAQI)</span>
-    {% else %}
-      <span class="govuk-caption-s govuk-!-margin-bottom-4">Mynegai Ansawdd Aer Dyddiol (DAQI)</span>
-    {% endif %}
+    <span class="govuk-caption-s govuk-!-margin-bottom-4">{{ daqi.heading }}</span>
     {{ daqiNumberedBar(airQuality.day2.value | default(0), airQuality.day2.readableBand | capitalize | default('')) }}
 
     {# Add daily summary details for day2 (tomorrow) #}
@@ -108,15 +110,15 @@
 {% endif %}
 
 {% if airQuality.day3 %}
-  {% set day3Label = 2 | addDaysToTodayAbrev %}
+  {% if lang == "en" %}
+    {% set day3Label = 2 | addDaysToTodayAbrev %}
+  {% else %}
+    {% set day3Label = 2 | addDaysToTodayAbrevWelsh %}
+  {% endif %}
   {% set day3TabClass = "govuk-tabs__tab daqi-tab--" + (airQuality.day3.value | default(0) | string) %}
   {% set day3Panel %}
     <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ day3Label }}</h2>
-    {% if lang == "en" %}
-      <span class="govuk-caption-s govuk-!-margin-bottom-4">Daily Air Quality Index (DAQI)</span>
-    {% else %}
-      <span class="govuk-caption-s govuk-!-margin-bottom-4">Mynegai Ansawdd Aer Dyddiol (DAQI)</span>
-    {% endif %}
+    <span class="govuk-caption-s govuk-!-margin-bottom-4">{{ daqi.heading }}</span>
     {{ daqiNumberedBar(airQuality.day3.value | default(0), airQuality.day3.readableBand | capitalize | default('')) }}
 
     {# Add daily summary details for day3 (part of remaining days range) #}
@@ -150,15 +152,15 @@
 {% endif %}
 
 {% if airQuality.day4 %}
-  {% set day4Label = 3 | addDaysToTodayAbrev %}
+  {% if lang == "en" %}
+    {% set day4Label = 3 | addDaysToTodayAbrev %}
+  {% else %}
+    {% set day4Label = 3 | addDaysToTodayAbrevWelsh %}
+  {% endif %}
   {% set day4TabClass = "govuk-tabs__tab daqi-tab--" + (airQuality.day4.value | default(0) | string) %}
   {% set day4Panel %}
     <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ day4Label }}</h2>
-    {% if lang == "en" %}
-      <span class="govuk-caption-s govuk-!-margin-bottom-4">Daily Air Quality Index (DAQI)</span>
-    {% else %}
-      <span class="govuk-caption-s govuk-!-margin-bottom-4">Mynegai Ansawdd Aer Dyddiol (DAQI)</span>
-    {% endif %}
+    <span class="govuk-caption-s govuk-!-margin-bottom-4">{{ daqi.heading }}</span>
     {{ daqiNumberedBar(airQuality.day4.value | default(0), airQuality.day4.readableBand | capitalize | default('')) }}
 
     {# Add daily summary details for day4 (part of remaining days range) #}
@@ -192,15 +194,15 @@
 {% endif %}
 
 {% if airQuality.day5 %}
-  {% set day5Label = 4 | addDaysToTodayAbrev %}
+  {% if lang == "en" %}
+    {% set day5Label = 4 | addDaysToTodayAbrev %}
+  {% else %}
+    {% set day5Label = 4 | addDaysToTodayAbrevWelsh %}
+  {% endif %}
   {% set day5TabClass = "govuk-tabs__tab daqi-tab--" + (airQuality.day5.value | default(0) | string) %}
   {% set day5Panel %}
     <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ day5Label }}</h2>
-    {% if lang == "en" %}
-      <span class="govuk-caption-s govuk-!-margin-bottom-4">Daily Air Quality Index (DAQI)</span>
-    {% else %}
-      <span class="govuk-caption-s govuk-!-margin-bottom-4">Mynegai Ansawdd Aer Dyddiol (DAQI)</span>
-    {% endif %}
+    <span class="govuk-caption-s govuk-!-margin-bottom-4">{{ daqi.heading }}</span>
     {{ daqiNumberedBar(airQuality.day5.value | default(0), airQuality.day5.readableBand | capitalize | default('')) }}
 
     {# Add daily summary details for day5 (part of remaining days range) #}

--- a/src/server/common/templates/partials/daqi.njk
+++ b/src/server/common/templates/partials/daqi.njk
@@ -1,9 +1,5 @@
 {% set daqiValue = airQuality.today.value %}
-  {% if lang == "en" %}
-    <span class="govuk-caption-s govuk-!-margin-bottom-4">Daily Air Quality Index (DAQI)</span>
-  {% else %}
-    <span class="govuk-caption-s govuk-!-margin-bottom-4">Mynegai Ansawdd Aer Dyddiol (DAQI)</span>
-  {% endif %}
+  <span class="govuk-caption-s govuk-!-margin-bottom-4">{{ daqi.heading }}</span>
   <div class="daqi-scale govuk-!-margin-bottom-7" role="img" aria-hidden="true">
   <div class="daqi-bar">
     {% for i in range(1, 11) %}

--- a/src/server/data/cy/cy.js
+++ b/src/server/data/cy/cy.js
@@ -1,15 +1,28 @@
 import { WELSH_TITLE } from '../constants.js'
+// Welsh month names for calendar use
+export const calendarWelsh = [
+  'Ionawr',
+  'Chwefror',
+  'Mawrth',
+  'Ebrill',
+  'Mai',
+  'Mehefin',
+  'Gorffennaf',
+  'Awst',
+  'Medi',
+  'Hydref',
+  'Tachwedd',
+  'Rhagfyr'
+]
 
 export const welsh = {
   home: {
     pageTitle: 'Gwirio ansawdd aer - GOV.UK',
     heading: `${WELSH_TITLE}`,
     caption:
-      "Mae'r mynegai ansawdd aer dyddiol(DAQI) yn dweud wrthoch chi am lefelau llygredd aer. Mae'n darparu cyngor iechyd ar gyfer y lefelau presennol.",
+      'Mae’r mynegai ansawdd aer dyddiol(DAQI) yn dweud wrthoch chi am lefelau llygredd aer. Mae’n darparu cyngor iechyd ar gyfer y lefelau presennol.',
     summaryText:
       'Sut y gall lefelau gwahanol o lygredd aer effeithio ar iechyd',
-    predictionLinkText: 'Darganfyddwch',
-    predictionLink: "sut mae llygredd aer yn cael ei ragweld a'i fesur",
     page: `${WELSH_TITLE}`,
     paragraphs: {
       a: 'Defnyddiwch y gwasanaeth yma:',
@@ -164,6 +177,9 @@ export const welsh = {
       'Mae’r mynegai ansawdd aer dyddiol(DAQI) yn dweud wrthoch chi am lefelau llygredd aer.Mae’n darparu cyngor iechyd ar gyfer y lefelau presennol.',
     summaryText:
       'Sut y gall lefelau gwahanol o lygredd aer effeithio ar iechyd',
+    heading: 'Mynegai Ansawdd Aer Dyddiol (DAQI)',
+    predictionLinkText: 'Gwybodaeth am',
+    predictionLink: 'sut mae llygredd aer yn cael ei rag-weld a’i fesur.',
     headText: {
       a: 'Lefel',
       b: 'Mynegai',
@@ -177,11 +193,11 @@ export const welsh = {
     },
     pageTexts: {
       a: 'Crynodeb o lygredd aer y UK',
-      b: 'Y diweddaraf am 5am ymlaen',
+      b: 'Y diweddariad diwethaf ddoe am 5am',
       c: 'Sut y gall llygryddion aer effeithio ar eich iechyd',
-      d: 'Llygryddion aer sy’n cael eu monitro gerllaw',
-      e: 'Rhagolwg y DU'
+      d: 'Llygryddion aer sy’n cael eu monitro gerllaw'
     },
+    predictedLevelsHeading: 'Lefelau llygredd aer a ragwelir',
     tabs: {
       today: 'Heddiw'
     },
@@ -371,7 +387,6 @@ export const welsh = {
   },
   dailySummaryTexts: {
     paragraphs: {
-      a: 'Rhagolwg y DU',
       b: 'Heddiw',
       c: 'Yfory',
       d: 'Rhagolwg'
@@ -547,17 +562,13 @@ export const welsh = {
   }
 }
 
-export const calendarWelsh = [
-  'Ionawr',
-  'Chwefror',
-  'Mawrth',
-  'Ebrill',
-  'Mai',
-  'Mehefin',
-  'Gorffennaf',
-  'Awst',
-  'Medi',
-  'Hydref',
-  'Tachwedd',
-  'Rhagfyr'
+// Welsh days of the week abbreviations for dynamic tab labels
+export const calendarWelshDays = [
+  'Sul', // Sunday
+  'Llun', // Monday
+  'Maw', // Tuesday
+  'Mer', // Wednesday
+  'Iau', // Thursday
+  'Gwe', // Friday
+  'Sad' // Saturday
 ]

--- a/src/server/data/en/en.js
+++ b/src/server/data/en/en.js
@@ -195,9 +195,11 @@ export const english = {
       d: 'Air pollutants monitored near by',
       e: ''
     },
+    predictedLevelsHeading: 'Predicted air pollution levels',
     tabs: {
       today: 'Today'
     },
+    heading: 'Daily Air Quality Index (DAQI)',
     pollutantText: {
       a: 'Particulate matter (PM)',
       b: 'Particulate matter are tiny pieces of solid or liquid particles suspended in the air. They come from sources like car tyres, brakes, exhausts, dust, wood burning and pollen.',
@@ -384,7 +386,6 @@ export const english = {
   },
   dailySummaryTexts: {
     paragraphs: {
-      a: 'UK air pollution summary',
       b: 'Today',
       c: 'Tomorrow',
       d: 'Outlook'

--- a/test/forecast-partial.test.js
+++ b/test/forecast-partial.test.js
@@ -26,6 +26,9 @@ const filters = require('../src/config/nunjucks/filters/index.js')
 if (filters && filters.addDaysToTodayAbrev) {
   filters.addDaysToTodayAbrev(env)
 }
+if (filters && filters.addDaysToTodayAbrevWelsh) {
+  filters.addDaysToTodayAbrevWelsh(env)
+}
 
 describe('forecast partial in DAQI tabs', () => {
   it('renders DAQI numbered block and tabs structure', () => {


### PR DESCRIPTION
- Add predictedLevelsHeading to English and Welsh translation files
- Update controllers to pass heading variable to templates
- Add heading display above DAQI tabs in daqi-numbered.njk template
- Fix import order and syntax errors in translation files
- Support both English and Welsh localized headings
- Fix test to register Welsh date filter