### PR TITLE
fix: add lang field to setupEmailAlert payload for backend API requir…

### DIFF
--- a/src/server/common/services/notify-backend.js
+++ b/src/server/common/services/notify-backend.js
@@ -172,6 +172,7 @@ export async function setupEmailAlert(
   locationId,
   lat,
   long,
+  lang,
   request = null
 ) {
   const setupPath = config.get('notify.setupAlertPath')
@@ -193,7 +194,8 @@ export async function setupEmailAlert(
     location: sanitizedLocation,
     locationId,
     lat: latitude,
-    long: longitude
+    long: longitude,
+    lang
   }
 
   if (mockSetupAlertEnabled) {

--- a/src/server/notify/register/email-confirm-link/controller.js
+++ b/src/server/notify/register/email-confirm-link/controller.js
@@ -193,6 +193,7 @@ const setupEmailAlertAndLog = async (
   locationId,
   lat,
   long,
+  lang,
   request
 ) => {
   const setupResult = await setupEmailAlert(
@@ -201,6 +202,7 @@ const setupEmailAlertAndLog = async (
     locationId,
     lat,
     long,
+    lang,
     request
   )
 
@@ -227,7 +229,7 @@ const getSetupOutcomeResponse = (setupResult, request, h, emailAddress) => {
   return redirectToAlertsSuccess(request, h)
 }
 
-const processValidToken = async (request, h, token) => {
+const processValidToken = async (request, h, token, lang) => {
   logger.info(
     `[EMAIL CONFIRM] Validating token: ${token.substring(0, TOKEN_LOG_PREFIX_LENGTH)}...`
   )
@@ -265,6 +267,7 @@ const processValidToken = async (request, h, token) => {
     locationId,
     lat,
     long,
+    lang,
     request
   )
 
@@ -296,7 +299,7 @@ export const handleEmailConfirmLinkRequest = async (request, h) => {
   }
 
   try {
-    return await processValidToken(request, h, token)
+    return await processValidToken(request, h, token, lang)
   } catch (error) {
     logger.error(`[EMAIL CONFIRM] Token validation failed: ${error.message}`)
 

--- a/src/server/notify/register/email-confirm-link/controller.test.js
+++ b/src/server/notify/register/email-confirm-link/controller.test.js
@@ -152,6 +152,7 @@ describe('email-confirm-link/controller', () => {
       'loc-2',
       53.95,
       -1.08,
+      'en',
       request
     )
     expect(response.redirect).toBe('/notify/register/alerts-success')

--- a/test/server/common/services/notify-backend.test.js
+++ b/test/server/common/services/notify-backend.test.js
@@ -262,6 +262,7 @@ describe('notify-backend service', () => {
       'loc-1',
       '53.8123456',
       '-1.1234567',
+      'en',
       null
     )
 
@@ -277,6 +278,7 @@ describe('notify-backend service', () => {
       'loc-2',
       '53.8123456',
       '-1.1234567',
+      'en',
       null
     )
 
@@ -292,7 +294,8 @@ describe('notify-backend service', () => {
           location: 'Leeds',
           locationId: 'loc-2',
           lat: 53.812346,
-          long: -1.123457
+          long: -1.123457,
+          lang: 'en'
         }
       }
     )
@@ -307,6 +310,7 @@ describe('notify-backend service', () => {
       'loc-3',
       null,
       undefined,
+      'en',
       null
     )
 
@@ -322,7 +326,8 @@ describe('notify-backend service', () => {
           location: nonStringLocation,
           locationId: 'loc-3',
           lat: undefined,
-          long: undefined
+          long: undefined,
+          lang: 'en'
         }
       }
     )


### PR DESCRIPTION
…ement

The backend /setup-alert endpoint now requires a lang field ('en' or 'cy'). Thread the resolved language from resolveNotifyLanguage(request) through processValidToken and setupEmailAlertAndLog to the service call, so the correct language is always sent without being hardcoded.